### PR TITLE
merge(#24): 게시글 등록 API

### DIFF
--- a/src/main/java/kr/co/numble/numble/domain/post/domain/presentation/PostController.java
+++ b/src/main/java/kr/co/numble/numble/domain/post/domain/presentation/PostController.java
@@ -1,0 +1,24 @@
+package kr.co.numble.numble.domain.post.domain.presentation;
+
+import kr.co.numble.numble.domain.post.domain.presentation.dto.request.PostUploadRequest;
+import kr.co.numble.numble.domain.post.domain.service.PostUploadService;
+import kr.co.numble.numble.global.response.GlobalResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+@RestController
+public class PostController {
+
+    private final PostUploadService postUploadService;
+
+    @PostMapping
+    public GlobalResponse<?> upload(@RequestBody @Valid PostUploadRequest postUploadRequest) {
+        postUploadService.upload(postUploadRequest);
+        return GlobalResponse.success("게시글 업로드 완료");
+    }
+
+}

--- a/src/main/java/kr/co/numble/numble/domain/post/domain/presentation/dto/request/PostUploadRequest.java
+++ b/src/main/java/kr/co/numble/numble/domain/post/domain/presentation/dto/request/PostUploadRequest.java
@@ -1,0 +1,17 @@
+package kr.co.numble.numble.domain.post.domain.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class PostUploadRequest {
+
+    @NotNull(message = "title은 Null을 허용하지 않습니다.")
+    private String title;
+
+    @NotNull(message = "content는 Null을 허용하지 않습니다.")
+    private String content;
+}

--- a/src/main/java/kr/co/numble/numble/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/kr/co/numble/numble/domain/post/domain/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package kr.co.numble.numble.domain.post.domain.repository;
+
+import kr.co.numble.numble.domain.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/kr/co/numble/numble/domain/post/domain/service/PostUploadService.java
+++ b/src/main/java/kr/co/numble/numble/domain/post/domain/service/PostUploadService.java
@@ -1,0 +1,26 @@
+package kr.co.numble.numble.domain.post.domain.service;
+
+import kr.co.numble.numble.domain.post.domain.Post;
+import kr.co.numble.numble.domain.post.domain.presentation.dto.request.PostUploadRequest;
+import kr.co.numble.numble.domain.post.domain.repository.PostRepository;
+import kr.co.numble.numble.domain.user.facade.UserFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PostUploadService {
+
+    private final PostRepository postRepository;
+    private final UserFacade userFacade;
+
+    @Transactional
+    public void upload(PostUploadRequest postUploadRequest) {
+        postRepository.save(Post.builder()
+                .title(postUploadRequest.getTitle())
+                .content(postUploadRequest.getContent())
+                .user(userFacade.getCurrentUser())
+                .build());
+    }
+}

--- a/src/main/java/kr/co/numble/numble/global/response/GlobalResponse.java
+++ b/src/main/java/kr/co/numble/numble/global/response/GlobalResponse.java
@@ -1,0 +1,53 @@
+package kr.co.numble.numble.global.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class GlobalResponse<T> {
+    private Boolean isSuccess;
+    private T data;
+    private String message;
+
+    public static <T> GlobalResponse<T> success() {
+        return GlobalResponse.<T>builder()
+                .isSuccess(true)
+                .message("")
+                .data(null)
+                .build();
+    }
+
+    public static <T> GlobalResponse<T> success(String message) {
+        return GlobalResponse.<T>builder()
+                .isSuccess(true)
+                .message(message)
+                .data(null)
+                .build();
+    }
+
+    public static <T> GlobalResponse<T> success(T data) {
+        return GlobalResponse.<T>builder()
+                .isSuccess(true)
+                .message("")
+                .data(data)
+                .build();
+    }
+
+    public static <T> GlobalResponse<T> success(T data, String message) {
+        return GlobalResponse.<T>builder()
+                .isSuccess(true)
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static <T extends HttpStatus> GlobalResponse<T> fail(String message) {
+        return GlobalResponse.<T>builder()
+                .isSuccess(false)
+                .message(message)
+                .data(null)
+                .build();
+    }
+}


### PR DESCRIPTION
- closes #24 

### Q. 질문사항
1. Jwt 토큰으로 User 정보를 불러오는 로직이 UserFacade의 getCurrentUser() 메서드라고 생각하고 PostUploadService을 작성했습니다. 해당 방법으로 진행하는게 맞을까요?
2. GlobalResponse를 작성헀는데, 혹시 기존에 Response 양식이 따로 있으신가요?