### PR TITLE
merge(#133): 문자 인증 중복 요청 제한

### DIFF
--- a/src/main/java/kr/co/souso/souso/domain/auth/service/CheckAuthCodeExistsService.java
+++ b/src/main/java/kr/co/souso/souso/domain/auth/service/CheckAuthCodeExistsService.java
@@ -5,10 +5,10 @@ import kr.co.souso.souso.domain.user.domain.UserAuthCode;
 import kr.co.souso.souso.domain.user.domain.repository.UserAuthCodeRepository;
 import kr.co.souso.souso.domain.user.exception.InvalidCodeException;
 import kr.co.souso.souso.domain.user.exception.UserAuthCodeNotFoundException;
-import kr.co.souso.souso.domain.user.facade.UserFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -16,13 +16,11 @@ public class CheckAuthCodeExistsService {
 
     private final UserAuthCodeRepository userAuthCodeRepository;
     private final PasswordEncoder passwordEncoder;
-    private final UserFacade userFacade;
 
+    @Transactional(readOnly = true)
     public void execute(CheckAuthCodeRequest request) {
         UserAuthCode authCode = userAuthCodeRepository.findById(request.getPhoneNumber())
                 .orElseThrow(() -> UserAuthCodeNotFoundException.EXCEPTION);
-
-        userFacade.checkUserPhoneNumber(request.getPhoneNumber());
 
         if (!passwordEncoder.matches(request.getAuthCode(), authCode.getCode())) {
             throw InvalidCodeException.EXCEPTION;

--- a/src/main/java/kr/co/souso/souso/domain/user/exception/AlreadyAuthCodeExistException.java
+++ b/src/main/java/kr/co/souso/souso/domain/user/exception/AlreadyAuthCodeExistException.java
@@ -1,0 +1,13 @@
+package kr.co.souso.souso.domain.user.exception;
+
+import kr.co.souso.souso.global.error.exception.GlobalErrorCode;
+import kr.co.souso.souso.global.error.exception.SousoException;
+
+public class AlreadyAuthCodeExistException extends SousoException {
+    public static final SousoException EXCEPTION =
+            new AlreadyAuthCodeExistException();
+
+    private AlreadyAuthCodeExistException() {
+        super(GlobalErrorCode.ALREADY_AUTH_CODE_EXIST);
+    }
+}

--- a/src/main/java/kr/co/souso/souso/global/error/exception/GlobalErrorCode.java
+++ b/src/main/java/kr/co/souso/souso/global/error/exception/GlobalErrorCode.java
@@ -38,6 +38,7 @@ public enum GlobalErrorCode {
     ALREADY_NICKNAME_EXIST(409, "Already Nickname Exist"),
     ALREADY_EMAIL_EXISTS(409, "Already Email Exist"),
     ALREADY_PHONE_NUMBER_EXIST(409, "Already Phone Number Exist"),
+    ALREADY_AUTH_CODE_EXIST(409, "Already Auth Code Exist"),
 
     // 500
     INTERNAL_SERVER_ERROR(500, "Internal Server Error");


### PR DESCRIPTION
- closes: #133 

UserAuthCodeService.class에 execute와 sendCode 메서드를 분리한 이유는 sendCode가 @Async 어노테이션을 통해 비동기 방식으로 작동하게끔 되어있는데 비동기의 경우 Exception이 발생하더라도 전역 예외 처리가 되지 않은 채 200 code가 내려가고 따로 서버에서만 에러 발생을 확인할 수 있기 때문입니다.

## 이미 가입된 번호에 문자 요청시 AlreadyPhoneNumberExistException 에러를 반환해야함.

1. swagger 
<img width="1380" alt="image" src="https://user-images.githubusercontent.com/74492426/205380457-4484fb76-379d-48b0-9b5a-39e246d2345b.png">

2. 서버
![image](https://user-images.githubusercontent.com/74492426/205380533-76678c00-fdc1-40e6-a688-6f65dd82ae93.png)

