### PR TITLE
merge(#160): 일괄 삭제를 위한 OneToMany 연결

### DIFF
--- a/src/main/java/kr/co/souso/souso/domain/bookmark/domain/repository/FeedBookmarkRepository.java
+++ b/src/main/java/kr/co/souso/souso/domain/bookmark/domain/repository/FeedBookmarkRepository.java
@@ -12,7 +12,5 @@ public interface FeedBookmarkRepository extends JpaRepository<FeedBookmark, Feed
 
     Optional<FeedBookmark> findByFeedAndUser(Feed feed, User user);
 
-    void deleteByFeed(Feed feed);
-
     Long countByUser(User user);
 }

--- a/src/main/java/kr/co/souso/souso/domain/category/domain/repository/FeedCategoryRepository.java
+++ b/src/main/java/kr/co/souso/souso/domain/category/domain/repository/FeedCategoryRepository.java
@@ -9,7 +9,4 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 public interface FeedCategoryRepository extends JpaRepository<FeedCategory, FeedCategoryId>{
 
     FeedCategory findFeedCategoryByFeedId(Long feedId);
-
-    void deleteByFeed(Feed feed);
-
 }

--- a/src/main/java/kr/co/souso/souso/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/kr/co/souso/souso/domain/comment/domain/repository/CommentRepository.java
@@ -12,7 +12,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     List<Comment> findCommentByFeedIdAndUserId(Long feedId, Long userId);
 
-    void deleteAllByFeed(Feed feed);
-
     Long countByUser(User user);
 }

--- a/src/main/java/kr/co/souso/souso/domain/feed/domain/Feed.java
+++ b/src/main/java/kr/co/souso/souso/domain/feed/domain/Feed.java
@@ -1,5 +1,9 @@
 package kr.co.souso.souso.domain.feed.domain;
 
+import kr.co.souso.souso.domain.bookmark.domain.FeedBookmark;
+import kr.co.souso.souso.domain.category.domain.FeedCategory;
+import kr.co.souso.souso.domain.comment.domain.Comment;
+import kr.co.souso.souso.domain.like.domain.FeedLike;
 import kr.co.souso.souso.domain.user.domain.User;
 import kr.co.souso.souso.global.entity.BaseTimeEntity;
 import lombok.AccessLevel;
@@ -10,6 +14,7 @@ import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,6 +44,21 @@ public class Feed extends BaseTimeEntity {
     @NotNull
     @ColumnDefault("0")
     private Long commentCount;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE)
+    private List<Comment> comments;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE)
+    private List<FeedLike> feedLikes;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE)
+    private List<FeedBookmark> feedBookmarks;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE)
+    private List<FeedImage> feedImages;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE)
+    private List<FeedCategory> feedCategories;
 
     @Builder
     public Feed(String content, User user, Long likeCount, Long bookmarkCount) {

--- a/src/main/java/kr/co/souso/souso/domain/feed/service/DeleteFeedService.java
+++ b/src/main/java/kr/co/souso/souso/domain/feed/service/DeleteFeedService.java
@@ -45,11 +45,6 @@ public class DeleteFeedService {
             throw NotValidUserException.EXCEPTION;
         }
         user.subFeed();
-        commentRepository.deleteAllByFeed(feed);
-        feedImageRepository.deleteAllByFeed(feed);
-        feedCategoryRepository.deleteByFeed(feed);
-        feedBookmarkRepository.deleteByFeed(feed);
-        feedLikeRepository.deleteByFeed(feed);
         feedRepository.delete(feed);
         feedViewCountRepository.delete(feedViewCount);
     }

--- a/src/main/java/kr/co/souso/souso/domain/like/domain/repository/FeedLikeRepository.java
+++ b/src/main/java/kr/co/souso/souso/domain/like/domain/repository/FeedLikeRepository.java
@@ -12,7 +12,5 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, FeedLikeId> 
 
     Optional<FeedLike> findByFeedAndUser(Feed feed, User user);
 
-    void deleteByFeed(Feed feed);
-
     Long countByUser(User user);
 }

--- a/src/main/java/kr/co/souso/souso/domain/user/domain/User.java
+++ b/src/main/java/kr/co/souso/souso/domain/user/domain/User.java
@@ -1,5 +1,7 @@
 package kr.co.souso.souso.domain.user.domain;
 
+import kr.co.souso.souso.domain.feed.domain.Feed;
+import kr.co.souso.souso.domain.meeting.domain.Meeting;
 import kr.co.souso.souso.domain.user.presentation.dto.request.UpdateUserInfoRequest;
 import kr.co.souso.souso.global.entity.BaseTimeEntity;
 import kr.co.souso.souso.global.enums.UserRole;
@@ -13,6 +15,7 @@ import org.hibernate.annotations.ColumnDefault;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -61,6 +64,12 @@ public class User extends BaseTimeEntity {
     @NotNull
     @ColumnDefault("0")
     private Long feedCount;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Feed> feeds;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Meeting> meetings;
 
     @Builder
     public User(String email, String password, String name, String phoneNumber, String nickname, String birth,


### PR DESCRIPTION
- closes: #160 

https://github.com/codestates-seb/seb40_main_001/pull/32

위 프로젝트를 참고하여 Join 을 걸지 않고 깔끔하게 OneToMany를 연결하여 cascade = CascadeType.REMOVE를 설정하는 방법을 보았습니다. 이를 통해 이슈에 명시한 대로 기존에 존재했던 엔티티를 삭제하기 위해 연관된 모든 엔티티들을 직접 순차적으로 삭제해야 했던 문제를 해결했습니다.